### PR TITLE
dfimage should ask for image tags instead of for hashes

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -23,10 +23,10 @@ class MainObj:
         for i in self.commands:
             print(i)
 
-    def _get_image(self, img_hash):
+    def _get_image(self, repo_tag):
         images = self.cli.images()
         for i in images:
-            if img_hash in i['Id']:
+            if repo_tag in i['RepoTags']:
                 self.img = i
                 return
         raise ImageNotFound("Image {} not found\n".format(img_hash))


### PR DESCRIPTION
## Description
In the documentation is stated that dfimage would ask for docker image names/tags. But reviewing the code, it checks for their SHA hashes.

## Related Issue
None, to my knowledge

## Motivation and Context
We had an Image in out own Gitlab repository but, unfortunately, the Git repository was empty, so we had no Dockerfile anywhere. I needed to reverse-engineer the image. And with this little modification, I was finally able to do so!

## How Has This Been Tested?
Manually

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document. ;)
