### PR TITLE
allow image id and ignore tag=none

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -23,9 +23,14 @@ class MainObj:
         for i in self.commands:
             print(i)
 
-    def _get_image(self, repo_tag):
+    def _get_image(self, repo_tag_or_id):
+        repo_tag = repo_tag_or_id if ':' in repo_tag_or_id else f"{repo_tag_or_id}:latest"
+        image_id = repo_tag_or_id.lower()
         images = self.cli.images()
         for i in images:
+            if i['Id'].split(':')[1].lower().startswith(image_id):
+                self.img = i
+                return
             rt = i['RepoTags']
             if rt and repo_tag in rt:
                 self.img = i

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -26,7 +26,8 @@ class MainObj:
     def _get_image(self, repo_tag):
         images = self.cli.images()
         for i in images:
-            if repo_tag in i['RepoTags']:
+            rt = i['RepoTags']
+            if rt and repo_tag in rt:
                 self.img = i
                 return
         raise ImageNotFound(f'Image {repo_tag} Not Found! '


### PR DESCRIPTION
This  PR 
- fixes a bug where image search throws exception when 'RepoTags' is None 
- defaults to tag 'latest' when tag is missing
- adds searching by image id 