### PR TITLE
Update Docker Publish GitHub Action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,12 +7,6 @@ on:
       - Dockerfile
       - entrypoint.*
       - requirements.txt
-  pull_request:
-    branches: [ master ]
-    paths:
-      - Dockerfile
-      - entrypoint.*
-      - requirements.txt
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
- Disable Docker Publish on PRs (causes images to get overwritten on PRs)