### PR TITLE
PyPI package fixes

### DIFF
--- a/.github/workflows/dfimage-test.yml
+++ b/.github/workflows/dfimage-test.yml
@@ -39,6 +39,15 @@ jobs:
           load: true
           tags: ${{ env.TEST_TAG }}
       
+      - name: Pull Docker Image for Test
+        run: docker pull ${{ env.IMAGE_TEST }}
+
       - name: Test Docker Container
         run: |
-          docker pull ${{ env.IMAGE_TEST }} && docker run -v /var/run/docker.sock:/var/run/docker.sock --rm ${{ env.TEST_TAG }} ${{ env.IMAGE_TEST }}
+          docker run -v /var/run/docker.sock:/var/run/docker.sock --rm ${{ env.TEST_TAG }} ${{ env.IMAGE_TEST }}
+
+      - name: Install with pipx
+        run: pipx install .
+
+      - name: Test pipx Install
+        run: dfimage ${{ env.IMAGE_TEST }}

--- a/.github/workflows/dfimage-test.yml
+++ b/.github/workflows/dfimage-test.yml
@@ -5,13 +5,13 @@ on:
     branches: [ master ]
     paths:
       - Dockerfile
-      - entrypoint.*
-      - requirements.txt
+      - dfimage.*
+      - pyproject.toml
   pull_request:
     branches: [ master ]
     paths:
       - Dockerfile
-      - entrypoint.*
+      - dfimage.*
       - pyproject.toml
   workflow_dispatch:
 

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -5,7 +5,7 @@ on:
     # branches: [ master ]
     # paths:
     #   - Dockerfile
-    #   - entrypoint.*
+    #   - dfimage.*
     #   - pyproject.toml
   workflow_dispatch:
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
     paths:
       - Dockerfile
-      - entrypoint.*
+      - dfimage.*
       - pyproject.toml
   workflow_dispatch:
 

--- a/dfimage.py
+++ b/dfimage.py
@@ -122,8 +122,11 @@ class MainObj:
                     self.from_img = self.layers_with_images[layer_id]
                     break
 
+
 def entrypoint():
+    """ """
     __main__ = MainObj()
+
 
 if __name__ == "__main__":
     entrypoint()

--- a/dfimage.py
+++ b/dfimage.py
@@ -122,5 +122,8 @@ class MainObj:
                     self.from_img = self.layers_with_images[layer_id]
                     break
 
+def entrypoint():
+    __main__ = MainObj()
 
-__main__ = MainObj()
+if __name__ == "__main__":
+    entrypoint()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dfimage"
-version = "1.0.0"
+version = "1.0.1"
 description = "Reverse-engineer a Dockerfile from a Docker Image"
 authors = [
   { name = "LanikSJ", email = "12159404+LanikSJ@users.noreply.github.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Reverse-engineer a Dockerfile from a Docker Image"
 authors = [
   { name = "LanikSJ", email = "12159404+LanikSJ@users.noreply.github.com" },
 ]
+readme = "README.md"
 license = { text = "MIT" }
 dependencies = ["docker==7.1.0"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ keywords = ["docker", "dockerfile", "reverse-engineer"]
 dev = ["build", "twine"]
 
 [project.scripts]
-dfimage = "entrypoint:__main__"
+dfimage = "dfimage:entrypoint"
 
 [tool.setuptools]
 py-modules = ['lib', 'lib64', 'dfimage', 'include']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
   { name = "LanikSJ", email = "12159404+LanikSJ@users.noreply.github.com" },
 ]
 readme = "README.md"
+requires-python = ">=3.8"
 license = { text = "MIT" }
 dependencies = ["docker==7.1.0"]
 classifiers = [


### PR DESCRIPTION
I tested the package on a few systems, several changes to make things work more smoothly:

* Added a CI test for pipx installing from the source directory (does a build/install similar to creating then installing the wheel files that are uploaded to PyPI). pipx manages creating a Python virtual environment for users so they don't need to think about activating/deactivating one that they installed dfimage into.
* Updated name of module/script name for entrypoint in pyproject.toml
* Updated pyproject.toml to include README.md as a long description that will appear on the PyPI page for dfimage
* Bumped version in pyproject.toml for patch release
* Updated some additional CI workflow triggers to match the new file names
*  Moved creation of MainObj() into a separate function that can be used for the entrypoint wrapper script pip creates (__main__ was not callable, and using MainObj directly printed some extraneous lines about the object being created/destroyed). I don't think there's anything special about setting a variable named __main__ in this context, other than potential for confusion with the __main__ module used when running a python script using e.g. python my script.py -- for that matter, things seem to work fine without setting any variable and just calling `MainObj()` on its own.
  - If someone wanted to integrate dfimage into their own Python script with `import dfimage` I think this will end up being cleaner (so dfimage won't try to analyze an image immediately on import, and will wait for the user to call the entrypoint function/create an instance of MainObj). Though there are some other changes that would be needed to make that a cleaner user experience.