### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -1,5 +1,9 @@
 name: Update License
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: '0 10 1 1 *' # 10:00 AM on January 1


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/dfimage/security/code-scanning/5](https://github.com/LanikSJ/dfimage/security/code-scanning/5)

To fix the issue, add a `permissions` block at the root of the workflow to explicitly define the minimal permissions required. Based on the workflow's functionality, it needs `contents: write` to update the license file and create a pull request, and `pull-requests: write` to merge the pull request. These permissions should be sufficient for the workflow to function correctly while minimizing unnecessary access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
