### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -56,6 +56,9 @@ jobs:
 
   # On closed events clean up any leftover Restyled PRs
   restyled-cleanup:
+    permissions:
+      contents: read
+      pull-requests: write
     if: ${{ github.event.action == 'closed' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/dfimage/security/code-scanning/4](https://github.com/LanikSJ/dfimage/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for each job. For the `restyled-cleanup` job, the `contents: read` and `pull-requests: write` permissions are sufficient, as the job only interacts with pull requests and does not require broader access.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs. In this case, we will add it to the `restyled-cleanup` job to ensure the permissions are scoped as narrowly as possible.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
