### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,5 +1,9 @@
 name: Restyled
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/dfimage/security/code-scanning/2](https://github.com/LanikSJ/dfimage/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations:
- `contents: read` is needed to check out the repository.
- `pull-requests: write` is required for creating and managing pull requests.
- Additional permissions (if any) will be added based on the specific needs of the workflow.

The `permissions` block will be added at the root level to apply to all jobs in the workflow. If any job requires different permissions, we can override them by adding a `permissions` block specific to that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
