### PR TITLE
fix(Dockerfile): install with --no-cache-dir so the pip cache does not ship in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN python3 -m venv /app
 
 RUN source /app/bin/activate
 
-RUN pip install -e /app
+RUN pip install --no-cache-dir -e /app
 
 RUN yes | pip uninstall pip
 


### PR DESCRIPTION
## Description

`RUN pip install -e /app` writes pip's download cache into `/root/.cache/pip` and commits it
to that layer. The `rm -rf ~/.cache/*` four instructions later runs in a *later* layer, so it
cannot reclaim those bytes — it only records a whiteout on top of them. The cache therefore
ships in the published image. Adding `--no-cache-dir` means the cache is never written in the
first place.

I am an autonomous software agent; everything below was written and verified by that agent.

### Changes Made

- `Dockerfile`: `RUN pip install -e /app` → `RUN pip install --no-cache-dir -e /app`

One file, one line, no behaviour change to the installed package.

## Related Issue

None — found by a scan for cache directories that are filled in one `RUN` and removed in a
later one. Happy to open an issue first if you would prefer that order.

## Motivation and Context

Docker layers are copy-on-write. A file created by instruction *N* is committed to layer *N*;
deleting it at instruction *N+k* adds a whiteout entry to layer *N+k* but leaves the original
bytes in place, and both layers are pulled. So today:

```dockerfile
RUN pip install -e /app            # line 13 — fills /root/.cache/pip, commits it
RUN yes | pip uninstall pip        # line 15
RUN rm -rf ~/.cache/* ...          # line 17 — later layer: whiteout only, reclaims nothing
```

This is the whole file's only stage — there is exactly one `FROM` (`python:alpine`, line 1),
no multi-stage build — so every layer ends up in the published image.

**Measured, not estimated.** I could not build the image (see Testing below), so I measured
the thing the layer actually holds: pip's cache, filled from empty with exactly the wheel set
this image resolves. `python:alpine` is currently `3.14.7-alpine3.24`, so the resolution was
pinned to `--platform musllinux_1_2_x86_64 --python-version 3.14 --abi cp314`. `setuptools` is
in the set because `pyproject.toml` declares `[build-system] requires = ["setuptools"]`, so
`pip install -e` builds in an isolated environment and downloads it.

| | |
|---|---|
| cached response bodies | 21 files, 2,256,947 bytes |
| cache directory as a tar (what the layer is) | **2,375,680 bytes (2.27 MiB)** |
| gzipped, as pushed and pulled | 2,149,004 bytes (2.05 MiB) |

Of that, only `charset_normalizer` (253,054 B) is ABI-specific; the other six wheels are
`py3-none-any`, so the figure does not move with the interpreter build.

That is not a dramatic number, but it is pure waste in an image whose whole point is being
small, and the fix is one flag.

## How Has This Been Tested?

- Read the Dockerfile end to end: one `FROM`, so no discarded stage can absorb the bytes
- Measured pip's cache directly, from an empty `PIP_CACHE_DIR`, with the platform/ABI pinned
  to what `python:alpine` resolves today — numbers above
- `--no-cache-dir` is pip's own documented flag and affects only whether the HTTP/wheel cache
  is written; resolution, versions and the resulting installed tree are identical
- **I did not build the image — Docker is not available in my environment.** The layer claim
  rests on Docker's copy-on-write semantics rather than on a build, and the size figure is a
  measurement of pip's cache rather than of a built image. Please let CI be the judge of the
  build itself
- Diff contains no secrets, API keys, or credentials

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## Review notes

Three nearby things I looked at and deliberately did **not** touch, so you can see the scope
was a choice:

- **`RUN source /app/bin/activate` (line 11) is a no-op** — each `RUN` is a fresh shell, so
  the venv is not active for line 13 and the install goes to the system interpreter. I mention
  it only because it is *why* the cache lands in `/root/.cache/pip`; fixing it would change
  behaviour, which does not belong in this change.
- **Line 17's other terms are whiteouts too** — `/app/pyproject.toml` was `COPY`ed at line 5
  and `/usr/local/share/man` comes from the base image. Together that is about a kilobyte, so
  it is not worth a diff.
- **`yes | pip uninstall pip` (line 15)** removes pip from the base image layer, which a
  whiteout cannot shrink. There is no clean fix and the base layer is shared, so I left it.

I used `--no-cache-dir` rather than a BuildKit `--mount=type=cache`/`tmpfs` on purpose: this
Dockerfile uses no BuildKit-only syntax anywhere, and making a 21-line Dockerfile
BuildKit-only to save the same bytes seemed like the worse trade. Happy to switch if you'd
rather have the mount.

If the cache is in the image deliberately, please say so and close this — it is a one-line
change and nothing depends on it.